### PR TITLE
feat: v1.3.0 null-safe and Map support

### DIFF
--- a/.kiro/specs/custom-formatter/.config.kiro
+++ b/.kiro/specs/custom-formatter/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "23df82ec-776b-4d1a-97d7-adf103175347", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/custom-formatter/design.md
+++ b/.kiro/specs/custom-formatter/design.md
@@ -1,0 +1,315 @@
+# Design Document: custom-formatter
+
+## Overview
+
+A feature **custom-formatter** adiciona suporte a formatadores customizados no `TemplateEngine`. O usuário registra instâncias de `CustomFormatter` no engine via `engine.registerFormatter("nome", formatter)`, e as referencia diretamente na sintaxe do template usando `${campo|nomeDoFormatter}`.
+
+Quando um placeholder usa a sintaxe `${path|formatterName}`, o pipeline de serialização Gson é bypassado: o valor resolvido via reflection é entregue diretamente ao formatter registrado, e a String retornada é usada como replacement. Placeholders sem formatter (`${path}`) continuam usando o pipeline Gson existente sem qualquer alteração.
+
+O engine passa a ter estado interno: um `Map<String, CustomFormatter>` que persiste entre chamadas a `process`.
+
+---
+
+## Architecture
+
+O fluxo de processamento existente é estendido em dois pontos:
+
+1. **Parsing do placeholder**: a regex passa a capturar opcionalmente o `|formatterName` após o path.
+2. **Despacho de serialização**: se o placeholder contém um formatter name, o engine busca o formatter no Map interno e o invoca; caso contrário, usa o pipeline Gson existente.
+
+```
+registerFormatter("nome", formatter)
+  └─ Map<String, CustomFormatter> interno ← armazena o formatter
+
+process(template, bean, serializationType)
+  │
+  ├─ Regex: Pattern.compile("\\$\\{([^|{}]+)(?:\\|([^}]+))?\\}")
+  │         Grupo 1: path (dot-notation)
+  │         Grupo 2: formatterName (opcional)
+  │
+  ├─ Para cada placeholder encontrado:
+  │     │
+  │     ├─ getPropertyValue(bean, path)  ← lógica existente, inalterada
+  │     │
+  │     ├─ Se grupo 2 presente (formatterName):
+  │     │     ├─ Busca formatter no Map → não encontrado → lança exceção
+  │     │     └─ formatter.format(path, resolvedValue)
+  │     │           ├─ RuntimeException → propagada diretamente
+  │     │           ├─ checked Exception → wrapped em SerializePropertyException
+  │     │           └─ null → "null"
+  │     │
+  │     └─ Se grupo 2 ausente:
+  │           └─ serializeProperty(bean, path, serializationType) ← inalterado
+  │
+  └─ StringBuffer com appendReplacement/appendTail → resultado final
+```
+
+### Diagrama de fluxo (Mermaid)
+
+```mermaid
+flowchart TD
+    A["process(template, bean, serializationType)"] --> B[compilar regex e iterar placeholders]
+    B --> C["getPropertyValue(bean, path)"]
+    C --> D{exceção na leitura?}
+    D -- sim --> E[propagar GetPropertyException]
+    D -- não --> F{placeholder tem formatterName?}
+    F -- não --> G["serializeProperty(bean, path, serializationType)"]
+    G --> L[appendReplacement no StringBuffer]
+    F -- sim --> H{formatter registrado?}
+    H -- não --> I[lançar FormatterNotFoundException]
+    H -- sim --> J["formatter.format(path, resolvedValue)"]
+    J --> K{exceção no formatter?}
+    K -- RuntimeException --> M[propagar sem wrapping]
+    K -- checked Exception --> N[wrap em SerializePropertyException]
+    K -- sem exceção --> O{retorno é null?}
+    O -- sim --> P[usar String 'null']
+    O -- não --> Q[usar String retornada]
+    P --> L
+    Q --> L
+    L --> R{mais placeholders?}
+    R -- sim --> B
+    R -- não --> S[appendTail → retornar resultado]
+```
+
+---
+
+## Components and Interfaces
+
+### CustomFormatter (nova interface)
+
+Interface funcional pública no pacote `io.github.moraesdelima.templateengine`.
+
+```java
+@FunctionalInterface
+public interface CustomFormatter {
+    /**
+     * Formats the resolved value of a placeholder.
+     *
+     * @param propertyName  the dot-notation path of the placeholder (e.g. "cliente.endereco.rua")
+     * @param resolvedValue the value resolved via reflection; may be {@code null}
+     * @return the String to be inserted in the template; if {@code null} is returned,
+     *         the engine will insert the literal String {@code "null"}
+     * @throws Exception if formatting fails; checked exceptions will be wrapped
+     *                   in {@link SerializePropertyException}
+     */
+    String format(String propertyName, Object resolvedValue) throws Exception;
+}
+```
+
+### FormatterNotFoundException (nova exceção)
+
+Exceção checked lançada quando um placeholder referencia um formatter não registrado. Estende `TemplateEngineException` seguindo a hierarquia existente.
+
+```java
+@Getter
+public class FormatterNotFoundException extends TemplateEngineException {
+    private final String formatterName;
+
+    public FormatterNotFoundException(String formatterName) {
+        super("Formatter not registered: " + formatterName);
+        this.formatterName = formatterName;
+    }
+}
+```
+
+### TemplateEngine (existente — estendido)
+
+**Novo campo de estado interno**
+
+```java
+private final Map<String, CustomFormatter> formatters = new HashMap<>();
+```
+
+**Novo método público `registerFormatter`**
+
+```java
+/**
+ * Registers a custom formatter under the given name.
+ * The formatter can be referenced in templates using the syntax ${path|name}.
+ *
+ * @param name      the formatter identifier (must not be null or empty)
+ * @param formatter the formatter implementation (must not be null)
+ * @throws IllegalArgumentException if name is null/empty or formatter is null
+ */
+public void registerFormatter(String name, CustomFormatter formatter) {
+    if (name == null || name.isEmpty()) {
+        throw new IllegalArgumentException("formatter name must not be null or empty");
+    }
+    if (formatter == null) {
+        throw new IllegalArgumentException("formatter must not be null");
+    }
+    formatters.put(name, formatter);
+}
+```
+
+**Alteração no método `process(String template, Object bean, int serializationType)`**
+
+A regex é atualizada para capturar o `formatterName` opcional. O loop de substituição despacha para o formatter ou para o pipeline Gson conforme o grupo capturado.
+
+```java
+// Regex atualizada — grupo 1: path, grupo 2: formatterName (opcional)
+Pattern pattern = Pattern.compile("\\$\\{([^|{}]+)(?:\\|([^}]+))?\\}");
+```
+
+**Novo método privado `applyFormatter`**
+
+```java
+private String applyFormatter(CustomFormatter formatter, String property,
+        Object resolvedValue, Class<?> beanClass)
+        throws SerializePropertyException {
+    try {
+        String result = formatter.format(property, resolvedValue);
+        return result == null ? "null" : result;
+    } catch (RuntimeException e) {
+        throw e;
+    } catch (Exception e) {
+        throw new SerializePropertyException(property, beanClass, e);
+    }
+}
+```
+
+**Métodos existentes — sem alteração de assinatura ou comportamento**
+
+- `process(String template, Object bean)` — inalterado
+- `serializeProperty(...)` — inalterado
+- `getPropertyValue(...)` — inalterado
+
+---
+
+## Data Models
+
+Nenhum modelo de dados de domínio é introduzido. As adições são:
+
+- Interface `CustomFormatter`
+- Exceção `FormatterNotFoundException`
+- Campo `Map<String, CustomFormatter> formatters` em `TemplateEngine`
+
+### Tabela de comportamentos — placeholders com formatter
+
+| Cenário | Resultado |
+|---|---|
+| `${nome\|uppercase}` com formatter `uppercase` registrado | `formatter.format("nome", value)` → resultado inserido |
+| `${nome\|uppercase}` com formatter `uppercase` NÃO registrado | `FormatterNotFoundException` lançada |
+| `${nome}` sem formatter (API existente) | pipeline Gson — comportamento inalterado |
+| `formatter.format` retorna `""` | string vazia inserida no template |
+| `formatter.format` retorna `null` | string literal `"null"` inserida |
+| `formatter.format` lança `RuntimeException` | propagada diretamente |
+| `formatter.format` lança checked `Exception` | wrapped em `SerializePropertyException` |
+| `registerFormatter` com name null/empty | `IllegalArgumentException` |
+| `registerFormatter` com formatter null | `IllegalArgumentException` |
+| `registerFormatter` com name já existente | formatter anterior substituído |
+
+### Hierarquia de exceções (atualizada)
+
+```
+Exception
+└── TemplateEngineException (checked)
+    ├── GetPropertyException         → falha na leitura (reflection)
+    ├── SerializePropertyException   → falha na serialização ou no formatter (checked)
+    └── FormatterNotFoundException   → formatter referenciado não está registrado
+```
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Formatter registrado é invocado com os argumentos corretos
+
+*For any* bean, template com placeholder `${path|name}` e formatter registrado sob `name`, o engine deve invocar `formatter.format(path, resolvedValue)` onde `resolvedValue` é exatamente o valor obtido via reflection para `path`.
+
+**Validates: Requirements 3.2, 6.1**
+
+### Property 2: Placeholder sem formatter preserva comportamento existente
+
+*For any* template contendo apenas placeholders no formato `${path}` (sem `|formatterName`), o resultado de `process(template, bean, serializationType)` deve ser idêntico ao resultado produzido antes desta feature.
+
+**Validates: Requirements 4.1, 4.2, 4.3, 3.4**
+
+### Property 3: Formatter não registrado lança exceção
+
+*For any* template com placeholder `${path|name}` onde `name` não foi registrado via `registerFormatter`, o engine deve lançar `FormatterNotFoundException` contendo o nome do formatter.
+
+**Validates: Requirements 3.3**
+
+### Property 4: Retorno null do formatter resulta em "null" no template
+
+*For any* formatter que retorna `null` para qualquer entrada, o placeholder correspondente no resultado final deve ser a string literal `"null"`.
+
+**Validates: Requirements 6.2**
+
+### Property 5: Registro substitui formatter anterior
+
+*For any* nome de formatter, registrar um novo formatter sob o mesmo nome e depois processar um template deve usar o formatter mais recentemente registrado.
+
+**Validates: Requirements 2.2**
+
+### Property 6: RuntimeException do formatter é propagada sem wrapping
+
+*For any* formatter que lança uma `RuntimeException`, o engine deve propagar exatamente essa exceção sem encapsulá-la.
+
+**Validates: Requirements 5.1**
+
+### Property 7: Checked exception do formatter é wrapped em SerializePropertyException
+
+*For any* formatter que lança uma checked `Exception`, o engine deve lançar `SerializePropertyException` tendo a exceção original como causa.
+
+**Validates: Requirements 5.2**
+
+---
+
+## Error Handling
+
+| Situação | Exceção | Quando |
+|---|---|---|
+| Propriedade inexistente no bean | `GetPropertyException` | Durante `getPropertyValue` |
+| Formatter referenciado não registrado | `FormatterNotFoundException` | Antes de invocar o formatter |
+| `RuntimeException` no formatter | propagada diretamente | Durante `formatter.format` |
+| checked `Exception` no formatter | `SerializePropertyException` (com cause) | Durante `formatter.format` |
+| `registerFormatter` com name null/empty | `IllegalArgumentException` | Em `registerFormatter` |
+| `registerFormatter` com formatter null | `IllegalArgumentException` | Em `registerFormatter` |
+| Tipo incompatível com STRING_SERIALIZATION | `SerializePropertyException` | Apenas em placeholders sem formatter |
+
+A ordem de verificação dentro do loop de substituição é:
+1. `getPropertyValue` — pode lançar `GetPropertyException`
+2. Verificar se há formatterName no placeholder
+3. Se sim: buscar no Map → `FormatterNotFoundException` se ausente → invocar formatter
+4. Se não: `serializeProperty` com pipeline Gson existente
+
+---
+
+## Testing Strategy
+
+### Abordagem dual: testes unitários + property-based tests
+
+**Testes unitários** cobrem exemplos concretos, casos de borda e condições de erro:
+- Registro e substituição de um formatter simples
+- Template com múltiplos formatters diferentes
+- Placeholder sem formatter ao lado de placeholder com formatter no mesmo template
+- Formatter retornando null → "null" no resultado
+- Formatter retornando string vazia
+- Formatter não registrado → `FormatterNotFoundException`
+- `registerFormatter` com argumentos inválidos → `IllegalArgumentException`
+- Substituição de formatter registrado (mesmo nome)
+- Exceção RuntimeException propagada do formatter
+- Exceção checked wrappada em `SerializePropertyException`
+
+**Property-based tests** validam as propriedades universais usando [jqwik](https://jqwik.net/) (biblioteca PBT para Java, compatível com JUnit 4/5):
+
+Cada property test deve rodar com mínimo de 100 iterações e ser anotado com o identificador da propriedade:
+
+```
+// Feature: custom-formatter, Property 1: formatter registrado é invocado com os argumentos corretos
+// Feature: custom-formatter, Property 2: placeholder sem formatter preserva comportamento existente
+// Feature: custom-formatter, Property 3: formatter não registrado lança exceção
+// Feature: custom-formatter, Property 4: retorno null do formatter resulta em "null"
+// Feature: custom-formatter, Property 5: registro substitui formatter anterior
+// Feature: custom-formatter, Property 6: RuntimeException propagada sem wrapping
+// Feature: custom-formatter, Property 7: checked exception wrapped em SerializePropertyException
+```
+
+**Configuração jqwik**:
+- Adicionar dependência `net.jqwik:jqwik` no `pom.xml`
+- Cada `@Property` usa `@Report(Reporting.GENERATED)` para rastreabilidade
+- Geradores customizados para beans de teste com valores aleatórios de String, int e objetos aninhados

--- a/.kiro/specs/custom-formatter/requirements.md
+++ b/.kiro/specs/custom-formatter/requirements.md
@@ -1,0 +1,91 @@
+# Requirements Document
+
+## Introduction
+
+Esta feature adiciona suporte a formatadores customizados no `TemplateEngine`. Atualmente, o engine resolve cada placeholder via reflection e serializa o valor usando Gson (STRING ou JSON). Com esta feature, o usuário poderá registrar funções de formatação (`CustomFormatter`) no engine via `registerFormatter`, e referenciá-las diretamente na sintaxe do template usando `${campo|nomeDoFormatter}`.
+
+Casos de uso típicos incluem: formatação de datas, mascaramento de CPF, aplicação de uppercase, formatação de moeda, entre outros. A API existente deve permanecer compatível — placeholders sem formatter (`${campo}`) continuam funcionando sem alteração.
+
+## Glossary
+
+- **TemplateEngine**: Classe principal da biblioteca, responsável por processar templates substituindo placeholders por valores extraídos de um Java Bean.
+- **Placeholder**: Expressão no formato `${path}` ou `${path|formatterName}` dentro do template, onde `path` é uma dot-notation que referencia uma propriedade do bean (ex: `${cliente.endereco.rua}`).
+- **CustomFormatter**: Interface funcional que recebe o nome da propriedade (String) e o valor resolvido (Object) e retorna a String final a ser inserida no template.
+- **Formatter**: Instância de `CustomFormatter` registrada no engine via `registerFormatter`.
+- **FormatterName**: Identificador string usado para referenciar um formatter registrado na sintaxe do template (ex: `uppercase` em `${cliente.nome|uppercase}`).
+- **Valor Resolvido**: O valor obtido via reflection a partir do bean para um dado placeholder, antes de qualquer serialização ou formatação.
+- **Serialização**: Processo de converter o valor resolvido em String, usando Gson com as regras de `STRING_SERIALIZATION` ou `JSON_SERIALIZATION`.
+
+## Requirements
+
+### Requirement 1: Interface CustomFormatter
+
+**User Story:** Como desenvolvedor que usa a biblioteca, quero uma interface funcional `CustomFormatter` para que eu possa implementar lógicas de formatação customizadas de forma simples e compatível com lambdas Java.
+
+#### Acceptance Criteria
+
+1. THE `TemplateEngine` library SHALL provide a `CustomFormatter` functional interface with a single method `format(String propertyName, Object resolvedValue)` that returns a `String`.
+2. THE `CustomFormatter` interface SHALL be annotated with `@FunctionalInterface` to allow lambda expressions.
+3. WHEN `resolvedValue` is `null`, THE `CustomFormatter` implementation SHALL receive `null` as the second argument and be responsible for handling it.
+
+---
+
+### Requirement 2: Registro de formatters no engine
+
+**User Story:** Como desenvolvedor, quero registrar formatters no engine via `registerFormatter` para que eu possa reutilizá-los em múltiplos templates sem passá-los como parâmetro a cada chamada.
+
+#### Acceptance Criteria
+
+1. THE `TemplateEngine` SHALL provide a method `registerFormatter(String name, CustomFormatter formatter)` that stores the formatter internally associated with the given name.
+2. WHEN `registerFormatter` is called with a name that is already registered, THE `TemplateEngine` SHALL replace the existing formatter with the new one.
+3. IF `name` is `null` or empty, THEN THE `TemplateEngine` SHALL throw an `IllegalArgumentException` with a descriptive message.
+4. IF `formatter` is `null`, THEN THE `TemplateEngine` SHALL throw an `IllegalArgumentException` with a descriptive message.
+5. THE `TemplateEngine` SHALL maintain the registered formatters as internal state (a `Map<String, CustomFormatter>`) across multiple calls to `process`.
+
+---
+
+### Requirement 3: Sintaxe de formatter no template
+
+**User Story:** Como desenvolvedor, quero referenciar um formatter diretamente na sintaxe do placeholder (`${campo|nomeDoFormatter}`) para que a intenção de formatação fique explícita no template.
+
+#### Acceptance Criteria
+
+1. THE `TemplateEngine` SHALL support the placeholder syntax `${path|formatterName}` where `formatterName` refers to a formatter previously registered via `registerFormatter`.
+2. WHEN a placeholder uses the `${path|formatterName}` syntax, THE `TemplateEngine` SHALL resolve the property value via reflection and then invoke the registered formatter with `(propertyName, resolvedValue)`, using the returned String as the replacement.
+3. WHEN a placeholder uses the `${path|formatterName}` syntax and the named formatter is NOT registered, THE `TemplateEngine` SHALL throw an exception indicating the unregistered formatter name.
+4. WHEN a placeholder uses the `${path}` syntax (no formatter), THE `TemplateEngine` SHALL apply the default serialization pipeline (Gson) as before, preserving existing behavior.
+
+---
+
+### Requirement 4: Compatibilidade com a API existente
+
+**User Story:** Como desenvolvedor que já usa a biblioteca, quero que meu código existente continue funcionando sem modificações para que a adoção da nova feature seja opcional.
+
+#### Acceptance Criteria
+
+1. THE `TemplateEngine` SHALL preserve the existing method signatures `process(String template, Object bean)` and `process(String template, Object bean, int serializationType)` without behavioral changes.
+2. WHEN `process(String template, Object bean)` is called, THE `TemplateEngine` SHALL behave identically to the behavior prior to this feature.
+3. WHEN `process(String template, Object bean, int serializationType)` is called, THE `TemplateEngine` SHALL behave identically to the behavior prior to this feature.
+
+---
+
+### Requirement 5: Propagação de exceções dentro do CustomFormatter
+
+**User Story:** Como desenvolvedor, quero que exceções lançadas dentro do meu formatter sejam propagadas de forma previsível para que eu possa tratar erros de formatação no meu código.
+
+#### Acceptance Criteria
+
+1. IF the `CustomFormatter.format` method throws a `RuntimeException`, THEN THE `TemplateEngine` SHALL propagate the exception without wrapping it.
+2. IF the `CustomFormatter.format` method throws a checked `Exception`, THEN THE `TemplateEngine` SHALL wrap it in a `SerializePropertyException` carrying the `propertyName` and the bean's `Class`.
+
+---
+
+### Requirement 6: Aplicação do formatter a cada placeholder
+
+**User Story:** Como desenvolvedor, quero que o formatter seja aplicado individualmente a cada placeholder que o referencia para que eu possa aplicar lógicas diferentes por nome de propriedade.
+
+#### Acceptance Criteria
+
+1. WHEN a template contains multiple placeholders with formatters, THE `TemplateEngine` SHALL invoke the respective `formatter.format(propertyName, resolvedValue)` once per placeholder, passing the exact dot-notation path as `propertyName` (ex: `"cliente.endereco.rua"`).
+2. WHEN `formatter.format` returns `null` for a placeholder, THE `TemplateEngine` SHALL insert the String `"null"` in place of that placeholder.
+3. WHEN `formatter.format` returns an empty String for a placeholder, THE `TemplateEngine` SHALL insert an empty String in place of that placeholder.

--- a/.kiro/specs/custom-formatter/tasks.md
+++ b/.kiro/specs/custom-formatter/tasks.md
@@ -1,0 +1,48 @@
+# Implementation Plan: custom-formatter
+
+## Overview
+
+Adiciona suporte a formatadores customizados no `TemplateEngine`. A implementação segue a ordem: nova interface e exceção → campo de estado e `registerFormatter` → atualização da regex e lógica de despacho → testes unitários.
+
+## Tasks
+
+- [ ] 1. Criar a interface `CustomFormatter` e a exceção `FormatterNotFoundException`
+  - Criar `CustomFormatter.java` no pacote `io.github.moraesdelima.templateengine` com a anotação `@FunctionalInterface` e o método `String format(String propertyName, Object resolvedValue) throws Exception`
+  - Criar `FormatterNotFoundException.java` estendendo `TemplateEngineException`, com campo `@Getter String formatterName` e mensagem `"Formatter not registered: " + formatterName`
+  - _Requirements: 1.1, 1.2, 3.3_
+
+- [ ] 2. Adicionar estado interno e `registerFormatter` ao `TemplateEngine`
+  - [ ] 2.1 Adicionar campo `private final Map<String, CustomFormatter> formatters = new HashMap<>()` em `TemplateEngine`
+    - _Requirements: 2.5_
+  - [ ] 2.2 Implementar método público `registerFormatter(String name, CustomFormatter formatter)` com validações de `null`/empty e Javadoc completo
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+  - [ ] 2.3 Escrever testes unitários para `registerFormatter`
+    - Registro simples, substituição de formatter existente, `name` null, `name` vazio, `formatter` null
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [ ] 3. Atualizar a regex e implementar o despacho de formatters em `process`
+  - [ ] 3.1 Substituir a regex em `process(String, Object, int)` por `Pattern.compile("\\$\\{([^|{}]+)(?:\\|([^}]+))?\\}")`
+    - Grupo 1: path; Grupo 2: formatterName (opcional)
+    - _Requirements: 3.1_
+  - [ ] 3.2 Implementar método privado `applyFormatter(CustomFormatter, String, Object, Class<?>)` que propaga `RuntimeException` diretamente e wrapa checked `Exception` em `SerializePropertyException`; retorna `"null"` quando o formatter retorna `null`
+    - _Requirements: 5.1, 5.2, 6.2, 6.3_
+  - [ ] 3.3 Atualizar o loop de substituição em `process` para: se grupo 2 presente → buscar formatter no Map (lançar `FormatterNotFoundException` se ausente) → chamar `applyFormatter`; se grupo 2 ausente → `serializeProperty` existente
+    - _Requirements: 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 6.1_
+  - [ ] 3.4 Escrever testes unitários para o despacho de formatters
+    - Formatter simples aplicado a um placeholder
+    - Template com múltiplos formatters diferentes
+    - Placeholder sem formatter ao lado de placeholder com formatter no mesmo template
+    - Formatter retornando `null` → `"null"` no resultado
+    - Formatter retornando string vazia
+    - Formatter não registrado → `FormatterNotFoundException`
+    - `RuntimeException` propagada do formatter
+    - Checked exception wrappada em `SerializePropertyException`
+    - _Requirements: 3.2, 3.3, 3.4, 5.1, 5.2, 6.1, 6.2, 6.3_
+
+- [ ] 4. Checkpoint final — garantir que todos os testes passam
+  - Garantir que todos os testes passam, inclusive os existentes em `TemplateEngineTest`. Perguntar ao usuário se houver dúvidas.
+
+## Notas
+
+- Nenhuma dependência nova necessária — testes cobertos com JUnit 4 existente
+- A regex atualizada é retrocompatível: placeholders sem `|formatterName` continuam funcionando

--- a/.kiro/specs/map-property-navigation/.config.kiro
+++ b/.kiro/specs/map-property-navigation/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "23df82ec-776b-4d1a-97d7-adf103175347", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/map-property-navigation/design.md
+++ b/.kiro/specs/map-property-navigation/design.md
@@ -1,0 +1,112 @@
+# Design Document: map-property-navigation
+
+## Overview
+
+A mudança é cirúrgica e localizada em um único método: `getPropertyValue` em `TemplateEngine`. A cada iteração do loop de segmentos, antes de tentar usar `PropertyDescriptor`, o engine verifica se o valor atual é uma instância de `Map`. Se sim, usa `map.get(property)` diretamente. Se não, mantém o comportamento existente com reflection.
+
+Nenhuma nova classe, interface ou dependência é necessária.
+
+---
+
+## Architecture
+
+```
+getPropertyValue(bean, "retorno.cbo.codigo")
+  │
+  ├─ segmento "retorno": value é TestBean → não é Map → reflection → retorna Map<String,Object>
+  │
+  ├─ segmento "cbo": value é Map → map.get("cbo") → retorna Map<String,Object>
+  │
+  └─ segmento "codigo": value é Map → map.get("codigo") → retorna "1234"
+```
+
+```
+getPropertyValue(bean, "cliente.nome")
+  │
+  ├─ segmento "cliente": value é TestBean → não é Map → reflection → retorna Cliente (Bean)
+  │
+  └─ segmento "nome": value é Cliente → não é Map → reflection → retorna "João"
+```
+
+### Diagrama de fluxo (Mermaid)
+
+```mermaid
+flowchart TD
+    A[para cada segmento do path] --> B{value == null?}
+    B -- sim --> C[return null]
+    B -- não --> D{value instanceof Map?}
+    D -- sim --> E["value = map.get(segment)"]
+    D -- não --> F[PropertyDescriptor via reflection]
+    F --> G{IntrospectionException?}
+    G -- sim --> H[lançar GetPropertyException]
+    G -- não --> I[getter.invoke]
+    I --> J{exceção?}
+    J -- sim --> K[lançar GetPropertyException]
+    J -- não --> L[value = resultado]
+    E --> L
+    L --> M{mais segmentos?}
+    M -- sim --> A
+    M -- não --> N[retornar value]
+```
+
+---
+
+## Components and Interfaces
+
+### TemplateEngine.getPropertyValue (modificado)
+
+Única alteração: adicionar o branch `instanceof Map` no início do loop, antes do `PropertyDescriptor`.
+
+```java
+for (String property : nestedProperties) {
+
+    if (value == null) {
+        return null;
+    }
+
+    // NEW: suporte a Map — usa map.get() em vez de reflection
+    if (value instanceof Map) {
+        value = ((Map<?, ?>) value).get(property);
+        beanClass = value != null ? value.getClass() : Object.class;
+        continue;
+    }
+
+    // comportamento existente — Java Bean via reflection
+    PropertyDescriptor pd;
+    try {
+        pd = new PropertyDescriptor(property, beanClass);
+    } catch (IntrospectionException e) {
+        throw new GetPropertyException(property, beanClass, e);
+    }
+    // ...
+}
+```
+
+Nenhum outro método é alterado. O `serializeProperty` recebe o valor folha e aplica as regras de serialização normalmente, independente de ter vindo de Map ou Bean.
+
+---
+
+## Data Models
+
+Nenhum modelo novo. O `Map` é tratado como nó de navegação — o engine não impõe restrições sobre o tipo genérico do Map (`Map<String, Object>`, `Map<Object, Object>`, etc.). A chave usada é sempre a String do segmento do path.
+
+### Tabela de comportamentos
+
+| Cenário | Resultado |
+|---|---|
+| Bean → Bean → String | valor via reflection em cada nível |
+| Bean → Map → String | reflection no Bean, map.get() no Map |
+| Map → Map → String | map.get() em cada nível |
+| Map → Bean → String | map.get() no Map, reflection no Bean |
+| Map com chave inexistente | null → "null" no template |
+| Map nulo em posição intermediária | null → "null" no template |
+| Bean com propriedade inexistente | GetPropertyException |
+
+---
+
+## Error Handling
+
+- Chave inexistente no Map: `map.get(key)` retorna `null` → null-safe navigation retorna `null` → template recebe `"null"`. Sem exceção.
+- Map nulo em posição intermediária: coberto pelo check `value == null` existente → retorna `null`.
+- Propriedade inexistente em Bean: comportamento inalterado → `GetPropertyException`.
+- Tipo de chave incompatível: `map.get(stringKey)` em Map com chaves não-String retorna `null` (sem ClassCastException em Java generics com raw types) → tratado como chave inexistente.

--- a/.kiro/specs/map-property-navigation/requirements.md
+++ b/.kiro/specs/map-property-navigation/requirements.md
@@ -1,0 +1,62 @@
+# Requirements Document
+
+## Introduction
+
+O `TemplateEngine` atualmente navega em paths com dot-notation (ex: `${retorno.cbo.codigo}`) usando `java.beans.PropertyDescriptor` via reflection. Quando um nó intermediário do path é do tipo `Map`, a reflection falha com `IntrospectionException` pois `Map` não possui getters convencionais.
+
+Esta feature adiciona suporte transparente à navegação em nós do tipo `Map<String, Object>` (ou qualquer `Map`) dentro de um path aninhado. Quando o valor atual durante a navegação for uma instância de `Map`, o `TemplateEngine` deve usar `map.get(property)` em vez de reflection para aquele segmento. A sintaxe do template permanece idêntica (`${path.aninhado}`), e a compatibilidade com Java Beans e com a navegação null-safe existente é preservada.
+
+## Glossary
+
+- **TemplateEngine**: Classe principal do projeto que processa templates substituindo expressões `${...}` pelos valores correspondentes no bean fornecido.
+- **Map_Node**: Um nó intermediário ou folha em um path de navegação cujo valor em runtime é uma instância de `java.util.Map`.
+- **Bean_Node**: Um nó intermediário ou folha em um path de navegação cujo valor em runtime é um Java Bean (POJO com getters via reflection).
+- **Path**: Sequência de segmentos separados por `.` dentro de uma expressão `${...}`, ex: `retorno.cbo.codigo`.
+- **Segment**: Um único identificador dentro de um Path, ex: `cbo` em `retorno.cbo.codigo`.
+- **Navigator**: Lógica interna do `TemplateEngine` responsável por percorrer os segmentos de um Path e resolver o valor final.
+- **Null_Safe_Navigation**: Comportamento existente onde, se um nó intermediário for `null`, o Navigator retorna `null` sem lançar exceção.
+
+## Requirements
+
+### Requirement 1: Navegação em Map_Node via map.get()
+
+**User Story:** Como desenvolvedor, quero usar a dot-notation `${retorno.cbo.codigo}` em templates mesmo quando `retorno` ou `cbo` são instâncias de `Map`, para que eu não precise converter Maps em Java Beans apenas para usar o TemplateEngine.
+
+#### Acceptance Criteria
+
+1. WHEN o Navigator encontra um Segment cujo valor atual é uma instância de `Map`, THE Navigator SHALL resolver o próximo valor chamando `map.get(segment)` em vez de usar `PropertyDescriptor`.
+2. WHEN o Navigator resolve um Segment via `map.get(segment)` e o resultado é um valor não-nulo, THE Navigator SHALL continuar a navegação nos segmentos restantes do Path usando o valor retornado.
+3. WHEN o Navigator resolve um Segment via `map.get(segment)` e a chave não existe no Map (resultado é `null`), THE Navigator SHALL retornar `null` para o Path completo, respeitando o comportamento de Null_Safe_Navigation.
+4. WHEN o Navigator encontra um Segment cujo valor atual é uma instância de `Map` e o Map contém uma chave cujo valor é outro `Map`, THE Navigator SHALL continuar a navegação no Map aninhado usando `map.get(segment)` para os segmentos subsequentes.
+5. THE TemplateEngine SHALL suportar Paths onde segmentos Bean_Node e Map_Node se alternam (ex: `beanProp.mapProp.outraBeanProp`).
+
+### Requirement 2: Compatibilidade com navegação em Bean_Node
+
+**User Story:** Como desenvolvedor, quero que a navegação em Java Beans continue funcionando exatamente como antes, para que a adição do suporte a Maps não quebre nenhum comportamento existente.
+
+#### Acceptance Criteria
+
+1. WHEN o Navigator encontra um Segment cujo valor atual não é uma instância de `Map`, THE Navigator SHALL usar `PropertyDescriptor` e reflection para resolver o valor, mantendo o comportamento atual.
+2. WHEN o Navigator falha ao criar um `PropertyDescriptor` para um Segment em um Bean_Node, THE Navigator SHALL lançar `GetPropertyException` com o nome do Segment e a classe do Bean_Node.
+3. WHEN o Navigator encontra um Bean_Node com getter que retorna `null`, THE Navigator SHALL retornar `null` para o Path completo, respeitando o comportamento de Null_Safe_Navigation.
+
+### Requirement 3: Compatibilidade com Null_Safe_Navigation
+
+**User Story:** Como desenvolvedor, quero que a navegação null-safe existente continue funcionando para nós do tipo Map, para que um Map nulo em posição intermediária retorne `"null"` no template sem lançar exceção.
+
+#### Acceptance Criteria
+
+1. WHEN o Navigator encontra um Map_Node cujo valor é `null` durante a navegação de um Path, THE Navigator SHALL retornar `null` para o Path completo sem lançar exceção.
+2. WHEN o Navigator encontra um Map_Node cujo valor é `null` e o TemplateEngine usa STRING_SERIALIZATION, THE TemplateEngine SHALL substituir a expressão pelo texto `"null"` no template resultante.
+3. WHEN o Navigator encontra um Map_Node cujo valor é `null` e o TemplateEngine usa JSON_SERIALIZATION, THE TemplateEngine SHALL substituir a expressão pelo texto `"null"` no template resultante.
+
+### Requirement 4: Serialização do valor folha resolvido via Map
+
+**User Story:** Como desenvolvedor, quero que o valor final resolvido a partir de um Map seja serializado pelas regras existentes de STRING_SERIALIZATION e JSON_SERIALIZATION, para que o comportamento de saída seja consistente independentemente de o valor ter vindo de um Bean ou de um Map.
+
+#### Acceptance Criteria
+
+1. WHEN o valor folha de um Path é resolvido via `map.get()` e é uma `String`, THE TemplateEngine SHALL serializar o valor seguindo as regras de STRING_SERIALIZATION e JSON_SERIALIZATION existentes.
+2. WHEN o valor folha de um Path é resolvido via `map.get()` e é um tipo numérico ou booleano, THE TemplateEngine SHALL serializar o valor seguindo as regras de STRING_SERIALIZATION e JSON_SERIALIZATION existentes.
+3. WHEN o valor folha de um Path é resolvido via `map.get()` e é um objeto complexo (Map ou outro Object), THE TemplateEngine SHALL serializar o valor seguindo as regras de STRING_SERIALIZATION e JSON_SERIALIZATION existentes (lançando `SerializePropertyException` para STRING_SERIALIZATION quando aplicável).
+4. FOR ALL valores folha resolvidos via `map.get()`, THE TemplateEngine SHALL produzir o mesmo resultado que produziria se o mesmo valor tivesse sido obtido via reflection de um Bean_Node equivalente.

--- a/.kiro/specs/map-property-navigation/tasks.md
+++ b/.kiro/specs/map-property-navigation/tasks.md
@@ -1,0 +1,41 @@
+# Implementation Plan: map-property-navigation
+
+## Overview
+
+Adiciona suporte a Map na navegação por dot-notation. A mudança é cirúrgica — um único branch no loop de `getPropertyValue` em `TemplateEngine`.
+
+## Tasks
+
+- [x] 1. Adicionar suporte a Map em getPropertyValue
+  - Em `TemplateEngine.getPropertyValue`, adicionar branch `instanceof Map` no início do loop, antes do `PropertyDescriptor`:
+    ```java
+    if (value instanceof Map) {
+        value = ((Map<?, ?>) value).get(property);
+        beanClass = value != null ? value.getClass() : Object.class;
+        continue;
+    }
+    ```
+  - Adicionar import `java.util.Map` se necessário
+  - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+- [x] 2. Adicionar bean de teste MapBean e testes unitários
+  - Criar `src/test/java/io/github/moraesdelima/templateengine/MapBean.java` com campo `Map<String, Object> dados` usando Lombok `@Data`
+  - Adicionar testes em `TemplateEngineTest`:
+    - Map simples: `${dados.nome}` onde `dados = {"nome": "João"}` → `"João"` com STRING_SERIALIZATION
+    - Map aninhado: `${dados.cbo.codigo}` onde `dados = {"cbo": {"codigo": "1234"}}` → `"1234"`
+    - Bean → Map → String: bean com campo Map, navegar até String dentro do Map
+    - Map → Bean → String: Map com valor Bean, navegar até propriedade do Bean
+    - Chave inexistente no Map: `${dados.inexistente}` → `"null"`
+    - Map nulo em posição intermediária: `${dados.cbo.codigo}` com `dados = null` → `"null"`
+    - Serialização JSON de valor String vindo de Map: `${dados.nome}` com JSON_SERIALIZATION → `"\"João\""`
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 3.1, 3.2, 3.3, 4.1, 4.2_
+
+- [x] 3. Checkpoint final — garantir que todos os testes passam
+  - Rodar `mvn test` e garantir que todos os testes passam, incluindo os existentes
+  - Perguntar ao usuário se houver dúvidas
+
+## Notas
+
+- Nenhuma dependência nova necessária
+- A mudança não afeta `serializeProperty` — o valor folha é serializado normalmente
+- Compatível com null-safe navigation já implementada

--- a/.kiro/specs/null-safe-path-navigation/.config.kiro
+++ b/.kiro/specs/null-safe-path-navigation/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "23df82ec-776b-4d1a-97d7-adf103175347", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/null-safe-path-navigation/design.md
+++ b/.kiro/specs/null-safe-path-navigation/design.md
@@ -1,0 +1,257 @@
+# Design Document: null-safe-path-navigation
+
+## Overview
+
+A feature **null-safe-path-navigation** altera o comportamento do `TemplateEngine` ao navegar por paths com dot-notation quando um segmento intermediário possui valor `null`. Em vez de lançar `GetPropertyException`, o engine retorna a string `"null"` como resultado da substituição do placeholder.
+
+A mudança já foi aplicada no código: o método `getPropertyValue` agora retorna `null` (em vez de lançar exceção) quando encontra `value == null` durante a iteração pelos segmentos do path. O `serializeProperty` já trata `null` corretamente via `gson.toJson(null)` → `"null"`.
+
+O escopo do design cobre:
+- A lógica de navegação null-safe já implementada em `getPropertyValue`
+- A atualização do teste de regressão existente
+- Novos testes para cobrir os cenários null-safe com ambos os tipos de serialização
+
+---
+
+## Architecture
+
+O fluxo de processamento permanece inalterado. A única mudança comportamental está dentro de `getPropertyValue`, no loop de iteração dos segmentos do path:
+
+```
+getPropertyValue(bean, "cliente.nome")
+  │
+  ├─ segmento "cliente": getter invocado → retorna null
+  │
+  ├─ próxima iteração: value == null → return null  ← NOVO COMPORTAMENTO
+  │
+  └─ (antes lançava GetPropertyException)
+```
+
+O `null` retornado por `getPropertyValue` é passado para `serializeProperty`, que chama `gson.toJson(null)` → `"null"` (string). Esse valor é usado como replacement no template.
+
+```
+process("O nome é ${cliente.nome}", bean, JSON_SERIALIZATION)
+  │
+  ├─ getPropertyValue(bean, "cliente.nome") → null  (cliente é null)
+  │
+  ├─ serializeProperty: gson.toJson(null) → "null"
+  │
+  └─ resultado: "O nome é null"
+```
+
+### Diagrama de fluxo (Mermaid)
+
+```mermaid
+flowchart TD
+    A[process: para cada placeholder] --> B[getPropertyValue]
+    B --> C{segmento intermediário é null?}
+    C -- sim --> D[return null]
+    C -- não --> E[invocar getter via reflection]
+    E --> F{propriedade existe?}
+    F -- não --> G[lançar GetPropertyException]
+    F -- sim --> H[continuar para próximo segmento]
+    H --> C
+    D --> I[serializeProperty: gson.toJson null → 'null']
+    I --> J[substituir placeholder por 'null' no template]
+```
+
+---
+
+## Components and Interfaces
+
+### TemplateEngine (existente — modificado)
+
+**Método `getPropertyValue` (privado)**
+
+Comportamento anterior:
+```java
+// Lançava GetPropertyException quando value == null durante iteração
+```
+
+Comportamento atual (já implementado):
+```java
+for (String property : nestedProperties) {
+    if (value == null) {
+        return null;  // null-safe: retorna null em vez de lançar exceção
+    }
+    // ... reflection para obter o getter
+}
+```
+
+**Método `serializeProperty` (privado) — sem alteração**
+
+Já trata `null` corretamente:
+- `gson.toJson(null)` → `"null"`
+- `JSON_SERIALIZATION`: retorna `"null"`
+- `STRING_SERIALIZATION`: o branch `serializedProperty.startsWith("\"")` não se aplica; o branch `!startsWith("{") && !startsWith("[")` captura `"null"` e retorna como está
+
+### TemplateEngineTest (existente — a ser atualizado)
+
+O teste `test_replacing_a_property_with_a_null_parent_with_TemplateEngine_JSON_SERIALIZATION` precisa ser convertido de um teste de exceção para um teste de substituição bem-sucedida. Além disso, deve ser adicionado o teste equivalente para `STRING_SERIALIZATION`.
+
+---
+
+## Data Models
+
+Nenhum modelo de dados novo é introduzido. Os modelos existentes permanecem inalterados:
+
+### GetPropertyException
+```java
+// Lançada apenas quando a propriedade não existe no bean (IntrospectionException)
+// ou quando o getter não é acessível
+// NÃO é mais lançada para segmentos intermediários null
+public class GetPropertyException extends TemplateEngineException {
+    private final String property;
+    private final Class<?> beanClass;
+}
+```
+
+### Tabela de comportamentos atualizada
+
+| Cenário | STRING_SERIALIZATION | JSON_SERIALIZATION |
+|---|---|---|
+| String `"João"` | `João` | `"João"` |
+| int `32` | `32` | `32` |
+| null (valor direto) | `null` | `null` |
+| **Parent null em path aninhado** | **`null`** ← alterado | **`null`** ← alterado |
+| Propriedade inexistente | lança `GetPropertyException` | lança `GetPropertyException` |
+| Object `{...}` | lança `SerializePropertyException` | `{"campo":"valor"}` |
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Null-safe navigation retorna "null"
+
+*For any* bean, path com dot-notation onde qualquer segmento intermediário possui valor `null`, e qualquer tipo de serialização (`STRING_SERIALIZATION` ou `JSON_SERIALIZATION`), o `TemplateEngine` deve substituir o placeholder pela string `"null"` sem lançar exceção.
+
+Raciocínio: 1.1 cobre o comportamento geral; 1.2 e 1.3 são especializações por `serializationType`; 2.1 é especialização por profundidade. Todos são subsumos desta propriedade universal parametrizada por serializationType e profundidade do path.
+
+**Validates: Requirements 1.1, 1.2, 1.3, 2.1**
+
+---
+
+### Property 2: Isolamento entre placeholders
+
+*For any* template com múltiplos placeholders onde apenas um possui segmento intermediário `null`, o `TemplateEngine` deve substituir somente o placeholder afetado por `"null"` e processar os demais normalmente, retornando seus valores corretos.
+
+Raciocínio: A presença de `null` em um placeholder não deve contaminar o processamento dos outros. Podemos gerar templates com N placeholders, setar um segmento como null, e verificar que os N-1 restantes foram substituídos corretamente.
+
+**Validates: Requirements 1.4**
+
+---
+
+### Property 3: GetPropertyException para propriedades inexistentes
+
+*For any* bean e qualquer nome de propriedade que não existe nesse bean, o `TemplateEngine` deve lançar `GetPropertyException` contendo exatamente o nome da propriedade que falhou e a classe exata do bean onde a falha ocorreu.
+
+Raciocínio: 1.5, 3.1, 3.2 e 3.3 testam o mesmo comportamento — lançamento de exceção + conteúdo correto. Combinados em uma única propriedade que verifica tanto o tipo da exceção quanto seus campos `property` e `beanClass`.
+
+**Validates: Requirements 1.5, 3.1, 3.2, 3.3**
+
+---
+
+### Property 4: Comportamento normal preservado para paths profundos sem null
+
+*For any* bean com path de profundidade 3 ou mais onde nenhum segmento é `null`, o `TemplateEngine` deve retornar o valor correto da propriedade final, sem alteração de comportamento em relação a paths mais rasos.
+
+Raciocínio: A mudança null-safe não deve afetar o caminho feliz. Paths profundos sem null devem continuar funcionando normalmente.
+
+**Validates: Requirements 2.2**
+
+---
+
+## Error Handling
+
+### Propriedades inexistentes — comportamento preservado
+
+`GetPropertyException` continua sendo lançada quando:
+- A propriedade não existe no bean (`IntrospectionException` ao criar `PropertyDescriptor`)
+- O getter não é acessível (`getter == null`)
+
+A exceção carrega `property` (nome exato da propriedade que falhou) e `beanClass` (classe exata onde a falha ocorreu), permitindo diagnóstico preciso.
+
+### Segmentos intermediários null — novo comportamento
+
+Quando `value == null` durante a iteração dos segmentos do path, `getPropertyValue` retorna `null` imediatamente. O `serializeProperty` converte esse `null` em `"null"` via `gson.toJson(null)`. Nenhuma exceção é lançada.
+
+### Serialização de tipos incompatíveis — comportamento preservado
+
+`SerializePropertyException` continua sendo lançada para `STRING_SERIALIZATION` quando o valor é um objeto complexo ou array. Não há interação com a feature null-safe.
+
+---
+
+## Testing Strategy
+
+### Abordagem dual: testes unitários + testes baseados em propriedades
+
+Os dois tipos são complementares e ambos são necessários:
+- **Testes unitários**: exemplos específicos, casos de regressão, condições de erro concretas
+- **Testes de propriedade**: validação universal das propriedades formais com inputs gerados aleatoriamente
+
+### Testes unitários (exemplos e regressão)
+
+Focados em:
+- Exemplo específico: `testBean.cliente = null`, template `"${cliente.nome}"`, resultado `"null"` com `JSON_SERIALIZATION` (Requirement 4.1)
+- Exemplo específico: `testBean.cliente = null`, template `"${cliente.nome}"`, resultado `"null"` com `STRING_SERIALIZATION` (Requirement 4.2)
+- Atualização do teste de regressão `test_replacing_a_property_with_a_null_parent_with_TemplateEngine_JSON_SERIALIZATION`: converter de `testReplacePropertiesThrowsAnException` para `testReplaceProperties` (Requirement 4.3)
+- Casos de borda: path com profundidade 3 (`a.b.c`) com segmento intermediário null
+
+### Testes baseados em propriedades (property-based testing)
+
+**Biblioteca**: [jqwik](https://jqwik.net/) — biblioteca de property-based testing para Java, integrada com JUnit 5. Alternativa: [QuickTheories](https://github.com/quicktheories/QuickTheories) para JUnit 4 (compatível com a estrutura atual do projeto que usa JUnit 4).
+
+> Nota: o projeto usa JUnit 4 (`org.junit.Test`). Recomenda-se **QuickTheories** para manter compatibilidade, ou migrar para JUnit 5 + jqwik.
+
+Cada propriedade deve ser implementada por um único teste de propriedade com mínimo de **100 iterações**.
+
+**Configuração de tags** (comentário em cada teste):
+```
+// Feature: null-safe-path-navigation, Property {N}: {texto da propriedade}
+```
+
+#### Property 1 — Null-safe navigation retorna "null"
+```java
+// Feature: null-safe-path-navigation, Property 1: null-safe navigation retorna "null"
+// Para qualquer bean com segmento intermediário null e qualquer serializationType,
+// o resultado deve ser "null"
+```
+Gerador: criar instâncias de `TestBean` com `cliente` setado como `null`, variar o `serializationType` entre `STRING_SERIALIZATION` e `JSON_SERIALIZATION`, verificar que `process("${cliente.nome}", bean, type)` retorna `"null"`.
+
+#### Property 2 — Isolamento entre placeholders
+```java
+// Feature: null-safe-path-navigation, Property 2: isolamento entre placeholders
+// Para qualquer template com múltiplos placeholders onde um tem segmento null,
+// os demais devem ser processados normalmente
+```
+Gerador: template com `${registro}` (válido) e `${cliente.nome}` (cliente null), verificar que `registro` é substituído corretamente e `cliente.nome` retorna `"null"`.
+
+#### Property 3 — GetPropertyException para propriedades inexistentes
+```java
+// Feature: null-safe-path-navigation, Property 3: GetPropertyException para propriedades inexistentes
+// Para qualquer nome de propriedade inexistente, deve lançar GetPropertyException
+// com property e beanClass corretos
+```
+Gerador: strings aleatórias que não correspondem a nenhuma propriedade de `TestBean`, verificar que `GetPropertyException` é lançada com `property` e `beanClass` corretos.
+
+#### Property 4 — Comportamento normal preservado para paths profundos sem null
+```java
+// Feature: null-safe-path-navigation, Property 4: comportamento normal para paths profundos sem null
+// Para qualquer bean com path de profundidade >= 3 sem null,
+// o valor correto deve ser retornado
+```
+Gerador: instâncias de `TestBean` com `cliente` e `endereco` não-null, verificar que `process("${cliente.endereco.rua}", bean, type)` retorna o valor correto de `rua`.
+
+### Cobertura esperada
+
+| Requirement | Tipo de teste | Cobertura |
+|---|---|---|
+| 1.1, 1.2, 1.3 | Property 1 | ✅ |
+| 1.4 | Property 2 | ✅ |
+| 1.5, 3.1, 3.2, 3.3 | Property 3 | ✅ |
+| 2.1 | Property 1 (path profundo com null) | ✅ |
+| 2.2 | Property 4 | ✅ |
+| 4.1, 4.2 | Testes unitários de exemplo | ✅ |
+| 4.3 | Atualização do teste de regressão | ✅ |

--- a/.kiro/specs/null-safe-path-navigation/requirements.md
+++ b/.kiro/specs/null-safe-path-navigation/requirements.md
@@ -1,0 +1,64 @@
+# Requirements Document
+
+## Introduction
+
+Atualmente, quando o `TemplateEngine` navega por um path com dot-notation (ex: `${cliente.endereco.rua}`) e encontra um segmento intermediário com valor `null` (ex: `cliente` é `null`), o método `getPropertyValue` lança `GetPropertyException`. A feature **null-safe-path-navigation** altera esse comportamento: em vez de lançar exceção, o engine deve retornar a string `"null"` no template, tornando a navegação null-safe. O teste existente `test_replacing_a_property_with_a_null_parent_with_TemplateEngine_JSON_SERIALIZATION` precisa ser atualizado para refletir o novo comportamento.
+
+## Glossary
+
+- **TemplateEngine**: Classe principal da biblioteca responsável por processar templates e substituir placeholders.
+- **Placeholder**: Expressão no formato `${path}` dentro de um template que será substituída pelo valor correspondente.
+- **Path**: Sequência de nomes de propriedades separados por `.` que identifica um valor dentro de um bean (ex: `cliente.endereco.rua`).
+- **Segmento intermediário**: Qualquer propriedade no path que não seja a última (ex: em `cliente.endereco.rua`, `cliente` e `endereco` são segmentos intermediários).
+- **Bean**: Objeto Java cujas propriedades são acessadas via reflection para substituição no template.
+- **GetPropertyException**: Exceção lançada quando uma propriedade não existe no bean ou não possui getter acessível.
+- **Null-safe navigation**: Comportamento em que a presença de `null` em um segmento intermediário do path não causa exceção, retornando `"null"` como valor final.
+
+## Requirements
+
+### Requirement 1: Navegação null-safe em paths aninhados
+
+**User Story:** Como desenvolvedor que usa o TemplateEngine, eu quero que placeholders com paths aninhados cujo segmento intermediário seja `null` retornem `"null"` no template, para que o processamento não seja interrompido por exceção.
+
+#### Acceptance Criteria
+
+1. WHEN o `TemplateEngine` processa um placeholder cujo segmento intermediário do path possui valor `null`, THE `TemplateEngine` SHALL substituir o placeholder pela string `"null"` no resultado final.
+2. WHEN o `TemplateEngine` processa um placeholder cujo segmento intermediário do path possui valor `null` com `JSON_SERIALIZATION`, THE `TemplateEngine` SHALL substituir o placeholder pela string `"null"` no resultado final.
+3. WHEN o `TemplateEngine` processa um placeholder cujo segmento intermediário do path possui valor `null` com `STRING_SERIALIZATION`, THE `TemplateEngine` SHALL substituir o placeholder pela string `"null"` no resultado final.
+4. WHEN o `TemplateEngine` processa um template com múltiplos placeholders e apenas um deles possui segmento intermediário `null`, THE `TemplateEngine` SHALL substituir apenas o placeholder afetado por `"null"` e processar os demais normalmente.
+5. IF uma propriedade referenciada no placeholder não existe no bean, THEN THE `TemplateEngine` SHALL lançar `GetPropertyException` com o nome da propriedade e a classe do bean.
+
+---
+
+### Requirement 2: Profundidade arbitrária de navegação null-safe
+
+**User Story:** Como desenvolvedor que usa o TemplateEngine, eu quero que a navegação null-safe funcione em qualquer nível de profundidade do path, para que paths com 3 ou mais segmentos também sejam tratados corretamente.
+
+#### Acceptance Criteria
+
+1. WHEN o `TemplateEngine` processa um placeholder com path de profundidade 3 ou mais (ex: `a.b.c.d`) e qualquer segmento intermediário é `null`, THE `TemplateEngine` SHALL retornar `"null"` sem lançar exceção.
+2. WHEN o `TemplateEngine` processa um placeholder com path de profundidade 3 ou mais e nenhum segmento é `null`, THE `TemplateEngine` SHALL retornar o valor da propriedade final normalmente.
+
+---
+
+### Requirement 3: Preservação do comportamento existente para propriedades inexistentes
+
+**User Story:** Como desenvolvedor que usa o TemplateEngine, eu quero que a mudança de comportamento para `null` não afete o tratamento de propriedades inexistentes, para que erros de digitação em placeholders continuem sendo sinalizados.
+
+#### Acceptance Criteria
+
+1. WHEN o `TemplateEngine` processa um placeholder cujo nome de propriedade não existe no bean, THE `TemplateEngine` SHALL lançar `GetPropertyException` contendo o nome da propriedade e a classe do bean onde a falha ocorreu.
+2. THE `GetPropertyException` SHALL conter o nome exato da propriedade que não foi encontrada.
+3. THE `GetPropertyException` SHALL conter a classe exata do bean onde a propriedade não foi encontrada.
+
+---
+
+### Requirement 4: Atualização do teste de regressão existente
+
+**User Story:** Como desenvolvedor que mantém o projeto, eu quero que o teste `test_replacing_a_property_with_a_null_parent_with_TemplateEngine_JSON_SERIALIZATION` seja atualizado para validar o novo comportamento null-safe, para que a suíte de testes reflita o comportamento atual do sistema.
+
+#### Acceptance Criteria
+
+1. THE `TemplateEngineTest` SHALL conter um teste que verifica que, quando `testBean.cliente` é `null`, o processamento do template `"${cliente.nome}"` retorna `"null"` com `JSON_SERIALIZATION`.
+2. THE `TemplateEngineTest` SHALL conter um teste que verifica que, quando `testBean.cliente` é `null`, o processamento do template `"${cliente.nome}"` retorna `"null"` com `STRING_SERIALIZATION`.
+3. WHEN o teste de regressão anterior esperava `GetPropertyException` para parent `null`, THE `TemplateEngineTest` SHALL substituir essa expectativa pela verificação do retorno `"null"`.

--- a/.kiro/specs/null-safe-path-navigation/tasks.md
+++ b/.kiro/specs/null-safe-path-navigation/tasks.md
@@ -1,0 +1,26 @@
+# Plano de Implementação: null-safe-path-navigation
+
+## Visão Geral
+
+A mudança no código já foi aplicada (`getPropertyValue` retorna `null` em vez de lançar exceção para segmentos intermediários null). O trabalho restante é atualizar o teste de regressão existente e adicionar novos testes unitários.
+
+## Tasks
+
+- [ ] 1. Atualizar teste de regressão e adicionar testes unitários em TemplateEngineTest
+  - [ ] 1.1 Atualizar test_replacing_a_property_with_a_null_parent_with_TemplateEngine_JSON_SERIALIZATION
+    - Converter de testReplacePropertiesThrowsAnException para testReplaceProperties
+    - Verificar que testBean.cliente = null + template "${cliente.nome}" retorna "null" com JSON_SERIALIZATION
+    - _Requirements: 4.1, 4.3_
+  - [ ] 1.2 Adicionar test_replacing_a_property_with_a_null_parent_with_TemplateEngine_STRING_SERIALIZATION
+    - Verificar que testBean.cliente = null + template "${cliente.nome}" retorna "null" com STRING_SERIALIZATION
+    - _Requirements: 4.2_
+  - [ ] 1.3 Adicionar test_replacing_a_deep_path_with_null_intermediate_segment
+    - Setar testBean.cliente.endereco = null, template "${cliente.endereco.rua}", verificar retorno "null" com ambos os tipos de serialização
+    - _Requirements: 2.1_
+
+- [ ] 2. Checkpoint final — garantir que todos os testes passam
+  - Garantir que todos os testes passam, perguntar ao usuário se houver dúvidas.
+
+## Notas
+
+- Nenhuma dependência nova necessária — testes cobertos com JUnit 4 existente

--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -1,0 +1,80 @@
+---
+inclusion: manual
+---
+
+# Arquitetura e Design do template-engine
+
+## Fluxo de Processamento
+
+```
+template (String) + bean (Object) + serializationType (int)
+        │
+        ▼
+  TemplateEngine.process()
+        │
+        ├─ Regex: Pattern.compile("\\$\\{([^}]+)\\}")
+        │         Captura tudo entre ${ e }
+        │
+        ├─ Para cada match encontrado:
+        │     │
+        │     ├─ getPropertyValue(bean, property)
+        │     │     │
+        │     │     ├─ Suporta propriedades aninhadas via "." (ex: cliente.endereco.rua)
+        │     │     ├─ Usa java.beans.PropertyDescriptor para localizar o getter
+        │     │     ├─ Invoca o getter via reflection (Method.invoke)
+        │     │     └─ Itera pelos segmentos do path, atualizando bean e beanClass
+        │     │
+        │     └─ serializeProperty(bean, property, serializationType)
+        │           │
+        │           ├─ Gson.toJson(propertyValue) → sempre serializa primeiro
+        │           │
+        │           ├─ JSON_SERIALIZATION (1): retorna o JSON bruto
+        │           │
+        │           └─ STRING_SERIALIZATION (0):
+        │                 ├─ null → retorna "null"
+        │                 ├─ String/Date (começa com ") → remove as aspas externas
+        │                 ├─ Number/Boolean (não começa com { ou [) → retorna como está
+        │                 └─ Object/Array (começa com { ou [) → lança SerializePropertyException
+        │
+        └─ StringBuffer com appendReplacement/appendTail → resultado final
+```
+
+## Decisões de Design
+
+### 1. Serialização via Gson como intermediário universal
+Todos os valores passam pelo `Gson.toJson()` antes de qualquer decisão de serialização. Isso garante consistência na representação de tipos primitivos, datas e objetos complexos. A distinção entre STRING e JSON é feita **após** a serialização Gson, inspecionando o primeiro caractere do JSON resultante.
+
+### 2. Propriedades aninhadas com dot-notation
+O método `getPropertyValue` divide o path por `.` e navega recursivamente pelo grafo de objetos. A cada nível, atualiza `beanClass` com o tipo de retorno do getter, permitindo navegação type-safe sem casting.
+
+### 3. Hierarquia de exceções checked
+```
+Exception
+└── TemplateEngineException (checked)
+    ├── GetPropertyException       → falha na leitura (reflection)
+    └── SerializePropertyException → falha na serialização (tipo incompatível)
+```
+Ambas carregam `property` (String) e `beanClass` (Class<?>) para diagnóstico preciso.
+
+### 4. Constantes de serialização como int
+`STRING_SERIALIZATION = 0` e `JSON_SERIALIZATION = 1` são constantes `public static final int`. Não é um enum — decisão de simplicidade da API pública.
+
+## Comportamentos Críticos
+
+| Cenário | STRING_SERIALIZATION | JSON_SERIALIZATION |
+|---|---|---|
+| String `"João"` | `João` | `"João"` |
+| int `32` | `32` | `32` |
+| boolean `true` | `true` | `true` |
+| null | `null` | `null` |
+| Object `{...}` | lança `SerializePropertyException` | `{"campo":"valor"}` |
+| List/Array | lança `SerializePropertyException` | `["v1","v2"]` |
+| Propriedade inexistente | lança `GetPropertyException` | lança `GetPropertyException` |
+| Parent null em path aninhado | lança `GetPropertyException` | lança `GetPropertyException` |
+
+## Limitações Conhecidas
+
+- `Gson` é instanciado como campo de instância (`Gson gson = new Gson()`), sem configuração customizada. Não há suporte a adaptadores de tipo, formatação de datas customizada, etc.
+- Não há suporte a expressões além de dot-notation (sem índices de array, sem condicionais).
+- `TemplateEngine` não é thread-safe se `Gson` for substituído por uma instância com estado.
+- O campo `gson` tem visibilidade package-private (sem modificador), o que pode ser intencional para testes mas é inconsistente com o encapsulamento da classe.

--- a/.kiro/steering/coding-standards.md
+++ b/.kiro/steering/coding-standards.md
@@ -1,0 +1,59 @@
+---
+inclusion: manual
+---
+
+# Padrões de Código e Convenções
+
+## Estilo Geral
+
+- Java 11, sem uso de features acima disso (records, sealed classes, etc.)
+- Lombok é usado nos beans de teste (`@Data`) e nas exceções (`@Getter`)
+- A classe principal `TemplateEngine` **não usa Lombok** — getters/setters não são necessários pois não há campos públicos de estado
+- Javadoc obrigatório em métodos públicos e privados da `TemplateEngine`
+- Encoding: UTF-8 em todos os arquivos
+
+## Nomenclatura
+
+- Classes: PascalCase (`TemplateEngine`, `GetPropertyException`)
+- Métodos: camelCase (`process`, `serializeProperty`, `getPropertyValue`)
+- Constantes: UPPER_SNAKE_CASE (`STRING_SERIALIZATION`, `JSON_SERIALIZATION`)
+- Testes: snake_case descritivo com prefixo `test_` (ex: `test_replacing_a_simple_property_with_TemplateEngine_JSON_SERIALIZATION_serialization_Type`)
+
+## Estrutura de Testes
+
+- Framework: JUnit 4 (runner atual), com dependências JUnit 5 disponíveis
+- Beans de teste ficam em `src/test/java` no mesmo pacote da classe testada
+- Padrão de setup: `@Before` / `@After` para inicialização e limpeza
+- Helpers privados para evitar repetição: `testReplaceProperties()` e `testReplacePropertiesThrowsAnException()`
+- Beans de teste usam Lombok `@Data` (gera getters, setters, equals, hashCode, toString)
+
+## Exceções
+
+- Todas as exceções do projeto estendem `TemplateEngineException` (checked)
+- Sempre incluir `property` e `beanClass` ao lançar exceções
+- Mensagens de erro seguem o padrão: `"Can't [ação] property [nome] from class [canonicalName]"`
+- Quando relevante, incluir o tipo de serialização na mensagem: `" witch TemplateEngine.[TIPO]_SERIALIZATION"`
+  - Nota: "witch" é um typo existente no código (deveria ser "with") — manter para não quebrar compatibilidade de mensagens
+
+## Adicionando Novas Funcionalidades
+
+1. Novos tipos de serialização devem ser constantes `public static final int` em `TemplateEngine`
+2. Novos tipos de exceção devem estender `TemplateEngineException`
+3. Novos beans de teste devem usar `@Data` do Lombok e ficar em `src/test/java/.../templateengine/`
+4. Todo novo método público deve ter Javadoc completo com `@param`, `@return` e `@throws`
+
+## Build
+
+```bash
+# Compilar e testar
+mvn package
+
+# Apenas testes
+mvn test
+
+# Deploy snapshot
+mvn deploy
+
+# Release com assinatura GPG
+mvn deploy -P ci-cd
+```

--- a/.kiro/steering/project-overview.md
+++ b/.kiro/steering/project-overview.md
@@ -1,0 +1,46 @@
+---
+inclusion: manual
+---
+
+# Visão Geral do Projeto: template-engine
+
+## Identidade do Projeto
+
+- **Artefato**: `io.github.moraesdelima:template-engine:1.2.0-SNAPSHOT`
+- **Tipo**: Biblioteca Java (JAR) publicada no Maven Central via Sonatype OSSRH
+- **Java**: 11+
+- **Build**: Apache Maven 3.x
+- **Licença**: MIT
+
+## Propósito
+
+Biblioteca de substituição de placeholders em templates de texto usando valores extraídos de Java Beans via reflection. Suporta dois modos de serialização: string pura e JSON (via Gson).
+
+## Estrutura de Pacotes
+
+```
+io.github.moraesdelima.templateengine
+├── TemplateEngine.java              # Classe principal (ponto de entrada da API)
+├── TemplateEngineException.java     # Exceção base (checked)
+├── GetPropertyException.java        # Falha ao ler propriedade via reflection
+└── SerializePropertyException.java  # Falha ao serializar valor da propriedade
+```
+
+## Dependências Principais
+
+| Dependência | Versão | Escopo | Uso |
+|---|---|---|---|
+| lombok | 1.18.26 | provided | `@Data`, `@Getter` nos beans e exceções |
+| gson | 2.10.1 | compile | Serialização JSON e normalização de tipos |
+| junit | 4.13.2 | test | Runner de testes (JUnit 4) |
+| junit-jupiter-api | 5.7.2 | test | API JUnit 5 (Jupiter) |
+| mockito-core | 4.2.0 | test | Mocks nos testes |
+| mockito-junit-jupiter | 4.2.0 | test | Integração Mockito + JUnit 5 |
+
+> Atenção: o projeto mistura JUnit 4 (`@Test` de `org.junit`) com dependências JUnit 5. Os testes atuais usam JUnit 4.
+
+## Pipeline de CI/CD
+
+- Profile `ci-cd` no Maven ativa: geração de sources JAR, javadoc JAR e assinatura GPG
+- Deploy via `nexus-staging-maven-plugin` para Sonatype OSSRH
+- Repositório snapshot: `https://s01.oss.sonatype.org/content/repositories/snapshots`

--- a/.kiro/steering/testing-guide.md
+++ b/.kiro/steering/testing-guide.md
@@ -1,0 +1,90 @@
+---
+inclusion: manual
+---
+
+# Guia de Testes
+
+## Estrutura dos Testes Existentes
+
+Os testes cobrem os seguintes cenários em `TemplateEngineTest`:
+
+| Teste | STRING | JSON |
+|---|---|---|
+| Propriedade simples (String) | ✅ | ✅ |
+| Propriedade aninhada (dot-notation) | ✅ | ✅ |
+| Múltiplas propriedades no mesmo template | ✅ | ✅ |
+| Propriedade do tipo Object | lança `SerializePropertyException` | ✅ |
+| Propriedade do tipo List/Array | lança `SerializePropertyException` | ✅ |
+| Propriedade com valor null | ✅ (`null`) | ✅ (`null`) |
+| Parent null em path aninhado | lança `GetPropertyException` | lança `GetPropertyException` |
+| Propriedade inexistente | lança `GetPropertyException` | lança `GetPropertyException` |
+
+## Beans de Teste Disponíveis
+
+### TestBean (raiz)
+```java
+@Data
+public class TestBean {
+    private String registro;    // "123456"
+    private Cliente cliente;
+    private List<String> lista; // ["value1"..."value5"]
+}
+```
+
+### Cliente
+```java
+@Data
+public class Cliente {
+    private String nome;     // "João"
+    private int idade;       // 32
+    private Endereco endereco;
+}
+```
+
+### Endereco
+```java
+@Data
+public class Endereco {
+    private String rua;   // "Silveira Martins"
+    private int numero;   // 30
+}
+```
+
+## Como Escrever Novos Testes
+
+### Teste de substituição bem-sucedida
+```java
+@Test
+public void test_[descricao]_with_[TIPO]_serialization_Type() {
+    testReplaceProperties(
+        "template com ${propriedade}",
+        "resultado esperado",
+        TemplateEngine.[TIPO]_SERIALIZATION);
+}
+```
+
+### Teste de exceção esperada
+```java
+@Test
+public void test_[descricao]_throws_[ExceptionType]() {
+    testReplacePropertiesThrowsAnException(
+        "template com ${propriedade}",
+        "nomePropriedade",       // property que causou o erro
+        ClasseDoBean.class,      // beanClass onde ocorreu o erro
+        TemplateEngine.[TIPO]_SERIALIZATION,
+        GetPropertyException.class // ou SerializePropertyException.class
+    );
+}
+```
+
+## Cenários Ainda Não Cobertos (gaps identificados)
+
+- Propriedade do tipo `Date` / `LocalDate` / `LocalDateTime`
+- Propriedade do tipo `enum`
+- Template vazio (`""`)
+- Template sem nenhum placeholder
+- Template com placeholder repetido (`${nome} e ${nome}`)
+- Propriedade com valor numérico `0` ou `false`
+- Profundidade de aninhamento > 2 níveis (ex: `a.b.c.d`)
+- Bean com herança (getter herdado de superclasse)
+- Propriedade com nome em camelCase composto (ex: `nomeCompleto`)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.moraesdelima</groupId>
     <artifactId>template-engine</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>template-engine</name>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
+            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/moraesdelima/templateengine/TemplateEngine.java
+++ b/src/main/java/io/github/moraesdelima/templateengine/TemplateEngine.java
@@ -4,6 +4,7 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -134,7 +135,13 @@ public class TemplateEngine {
         for (String property : nestedProperties) {
 
             if (value == null) {
-                throw new GetPropertyException(property, beanClass);
+                return null;
+            }
+
+            if (value instanceof Map) {
+                value = ((Map<?, ?>) value).get(property);
+                beanClass = value != null ? value.getClass() : Object.class;
+                continue;
             }
 
             PropertyDescriptor pd;

--- a/src/test/java/io/github/moraesdelima/templateengine/MapBean.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/MapBean.java
@@ -1,0 +1,10 @@
+package io.github.moraesdelima.templateengine;
+
+import java.util.Map;
+
+import lombok.Data;
+
+@Data
+public class MapBean {
+    private Map<String, Object> dados;
+}

--- a/src/test/java/io/github/moraesdelima/templateengine/TemplateEngineTest.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/TemplateEngineTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -190,11 +191,32 @@ public class TemplateEngineTest {
     @Test
     public void test_replacing_a_property_with_a_null_parent_with_TemplateEngine_JSON_SERIALIZATION_serialization_Type() {
         testBean.setCliente(null);
-        testReplacePropertiesThrowsAnException(
+        testReplaceProperties(
                 "O registro do cliente é ${registro}, o nome do cliente é ${cliente.nome}, a idade é ${cliente.idade} e o endereco é Rua ${cliente.endereco.rua}, ${cliente.endereco.numero}.",
-                "nome", Cliente.class,
-                TemplateEngine.JSON_SERIALIZATION,
-                GetPropertyException.class);
+                "O registro do cliente é \"123456\", o nome do cliente é null, a idade é null e o endereco é Rua null, null.",
+                TemplateEngine.JSON_SERIALIZATION);
+    }
+
+    @Test
+    public void test_replacing_a_property_with_a_null_parent_with_TemplateEngine_STRING_SERIALIZATION_serialization_Type() {
+        testBean.setCliente(null);
+        testReplaceProperties(
+                "${cliente.nome}",
+                "null",
+                TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test
+    public void test_replacing_a_deep_path_with_null_intermediate_segment() {
+        testBean.getCliente().setEndereco(null);
+        testReplaceProperties(
+                "${cliente.endereco.rua}",
+                "null",
+                TemplateEngine.STRING_SERIALIZATION);
+        testReplaceProperties(
+                "${cliente.endereco.rua}",
+                "null",
+                TemplateEngine.JSON_SERIALIZATION);
     }
 
     @Test
@@ -213,6 +235,99 @@ public class TemplateEngineTest {
                 "nonExistentProperty", TestBean.class,
                 TemplateEngine.STRING_SERIALIZATION,
                 GetPropertyException.class);
+    }
+
+    // --- Map navigation tests ---
+
+    @Test
+    public void test_map_simple_string_value_with_STRING_SERIALIZATION() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("nome", "João"));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.nome}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            assertEquals("João", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_map_nested_map_value_with_STRING_SERIALIZATION() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("cbo", Map.of("codigo", "1234")));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.cbo.codigo}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            assertEquals("1234", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_bean_to_map_to_string_navigation() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("nome", "João"));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.nome}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            assertEquals("João", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_map_to_bean_to_string_navigation() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("cliente", cliente));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.cliente.nome}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            assertEquals("João", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_map_missing_key_returns_null_string() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("nome", "João"));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.inexistente}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            assertEquals("null", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_null_map_in_intermediate_position_returns_null_string() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(null);
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.cbo.codigo}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            assertEquals("null", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_map_string_value_with_JSON_SERIALIZATION() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("nome", "João"));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.nome}", testBean, TemplateEngine.JSON_SERIALIZATION);
+            assertEquals("\"João\"", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
     }
 
 }

--- a/src/test/java/io/github/moraesdelima/templateengine/TestBean.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/TestBean.java
@@ -9,4 +9,5 @@ public class TestBean {
     private String registro;
     private Cliente cliente;
     private List<String> lista;
+    private MapBean mapBean;
 }


### PR DESCRIPTION
## O que muda nessa versão

### feat: null-safe path navigation
Quando um segmento intermediário do path é null, o engine retorna "null" no template em vez de lançar GetPropertyException. Válido para qualquer profundidade de path e ambos os modos de serialização.

### feat: suporte a Map na navegação por dot-notation
Quando um nó do path é uma instância de Map, o engine usa map.get(property) em vez de reflection. Suporta alternância Bean/Map em qualquer nível do path.

### chore: bump version to 1.3.0

## Impacto nos testes
- 1 teste atualizado (null-safe: esperava GetPropertyException, agora espera "null")
- 10 novos testes adicionados
- Total: 24 testes, BUILD SUCCESS
