### PR TITLE
fix: allow getter-only properties without requiring setter (1.3.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.moraesdelima</groupId>
     <artifactId>template-engine</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>template-engine</name>

--- a/src/main/java/io/github/moraesdelima/templateengine/TemplateEngine.java
+++ b/src/main/java/io/github/moraesdelima/templateengine/TemplateEngine.java
@@ -146,7 +146,8 @@ public class TemplateEngine {
 
             PropertyDescriptor pd;
             try {
-                pd = new PropertyDescriptor(property, beanClass);
+                String getterName = "get" + Character.toUpperCase(property.charAt(0)) + property.substring(1);
+                pd = new PropertyDescriptor(property, beanClass, getterName, null);
             } catch (IntrospectionException e) {
                 throw new GetPropertyException(property, beanClass, e);
             }


### PR DESCRIPTION
## Fix

PropertyDescriptor agora é criado com null no setter, permitindo getters sem campo declarado e sem setter correspondente.

### Problema
Ao usar um getter virtual para converter tipos como LocalDate em String, o PropertyDescriptor lançava exceção por não encontrar o setter.

### Solução
Substituído new PropertyDescriptor(property, beanClass) por new PropertyDescriptor(property, beanClass, getterName, null).

### Versão
1.3.0 -> 1.3.1