### PR TITLE
fix: register Gson TypeAdapters for java.time types (1.3.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.moraesdelima</groupId>
     <artifactId>template-engine</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <packaging>jar</packaging>
 
     <name>template-engine</name>

--- a/src/main/java/io/github/moraesdelima/templateengine/TemplateEngine.java
+++ b/src/main/java/io/github/moraesdelima/templateengine/TemplateEngine.java
@@ -4,11 +4,17 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,7 +30,14 @@ public class TemplateEngine {
 
     public static final int STRING_SERIALIZATION = 0;
     public static final int JSON_SERIALIZATION = 1;
-    Gson gson = new Gson();
+    Gson gson = new GsonBuilder()
+            .registerTypeAdapter(LocalDate.class,
+                    (JsonSerializer<LocalDate>) (src, type, ctx) -> new JsonPrimitive(src.toString()))
+            .registerTypeAdapter(LocalDateTime.class,
+                    (JsonSerializer<LocalDateTime>) (src, type, ctx) -> new JsonPrimitive(src.toString()))
+            .registerTypeAdapter(LocalTime.class,
+                    (JsonSerializer<LocalTime>) (src, type, ctx) -> new JsonPrimitive(src.toString()))
+            .create();
 
     public String process(String template, Object bean)
             throws GetPropertyException, SerializePropertyException {


### PR DESCRIPTION
## Fix

Registra TypeAdapters no GsonBuilder para LocalDate, LocalDateTime e LocalTime, resolvendo o erro:

`Failed making field 'java.time.LocalDate#year' accessible`

Os tipos são serializados como string ISO (ex: "2024-03-27") sem necessidade de getter auxiliar.

### Versão
1.3.1 -> 1.3.2