### PR TITLE
feat: custom-formatter support (1.4.0)

### DIFF
--- a/src/main/java/io/github/moraesdelima/templateengine/CustomFormatter.java
+++ b/src/main/java/io/github/moraesdelima/templateengine/CustomFormatter.java
@@ -1,0 +1,28 @@
+package io.github.moraesdelima.templateengine;
+
+/**
+ * Functional interface for custom value formatters in {@link TemplateEngine}.
+ * <p>
+ * Implementations receive the dot-notation path of the placeholder and the
+ * resolved value, and return the String to be inserted in the template.
+ * <p>
+ * Register a formatter via {@link TemplateEngine#registerFormatter(String, CustomFormatter)}
+ * and reference it in templates using the syntax {@code ${path|formatterName}}.
+ *
+ * @author <a href="mailto:luiz.moraes@zipdin.com.br">luiz.moraes</a>
+ */
+@FunctionalInterface
+public interface CustomFormatter {
+
+    /**
+     * Formats the resolved value of a placeholder.
+     *
+     * @param propertyName  the dot-notation path of the placeholder (e.g. "cliente.endereco.rua")
+     * @param resolvedValue the value resolved via reflection; may be {@code null}
+     * @return the String to be inserted in the template; if {@code null} is returned,
+     *         the engine will insert the literal String {@code "null"}
+     * @throws Exception if formatting fails; checked exceptions will be wrapped
+     *                   in {@link SerializePropertyException}
+     */
+    String format(String propertyName, Object resolvedValue) throws Exception;
+}

--- a/src/main/java/io/github/moraesdelima/templateengine/FormatterNotFoundException.java
+++ b/src/main/java/io/github/moraesdelima/templateengine/FormatterNotFoundException.java
@@ -1,0 +1,20 @@
+package io.github.moraesdelima.templateengine;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when a placeholder references a formatter that has not been
+ * registered in the {@link TemplateEngine}.
+ *
+ * @author <a href="mailto:luiz.moraes@zipdin.com.br">luiz.moraes</a>
+ */
+@Getter
+public class FormatterNotFoundException extends TemplateEngineException {
+
+    private final String formatterName;
+
+    public FormatterNotFoundException(String formatterName) {
+        super("Formatter not registered: " + formatterName);
+        this.formatterName = formatterName;
+    }
+}

--- a/src/main/java/io/github/moraesdelima/templateengine/TemplateEngine.java
+++ b/src/main/java/io/github/moraesdelima/templateengine/TemplateEngine.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -30,6 +31,7 @@ public class TemplateEngine {
 
     public static final int STRING_SERIALIZATION = 0;
     public static final int JSON_SERIALIZATION = 1;
+    private final Map<String, CustomFormatter> formatters = new HashMap<>();
     Gson gson = new GsonBuilder()
             .registerTypeAdapter(LocalDate.class,
                     (JsonSerializer<LocalDate>) (src, type, ctx) -> new JsonPrimitive(src.toString()))
@@ -40,40 +42,81 @@ public class TemplateEngine {
             .create();
 
     public String process(String template, Object bean)
-            throws GetPropertyException, SerializePropertyException {
+            throws GetPropertyException, SerializePropertyException, FormatterNotFoundException {
         return process(template, bean, STRING_SERIALIZATION);
+    }
+
+    /**
+     * Registers a custom formatter under the given name.
+     * The formatter can be referenced in templates using the syntax {@code ${path|name}}.
+     *
+     * @param name      the formatter identifier (must not be null or empty)
+     * @param formatter the formatter implementation (must not be null)
+     * @throws IllegalArgumentException if name is null/empty or formatter is null
+     */
+    public void registerFormatter(String name, CustomFormatter formatter) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("formatter name must not be null or empty");
+        }
+        if (formatter == null) {
+            throw new IllegalArgumentException("formatter must not be null");
+        }
+        formatters.put(name, formatter);
     }
 
     /**
      * Replaces all properties in the given template with their respective values
      * from the given Java Bean object.
-     * 
+     *
      * @param template          the template with properties to be replaced
      * @param bean              the Java Bean object containing the property values
      * @param serializationType the type of serialization to be used for the
      *                          property values (either STRING_SERIALIZATION or
      *                          JSON_SERIALIZATION)
-     * @return the template with all properties replaced with their respective
-     *         values
-     * @throws GetPropertyException       if the value of a property cannot be
-     *                                    obtained from the Java Bean object
-     * @throws SerializePropertyException if an error occurs during serialization of
-     *                                    a property value
+     * @return the template with all properties replaced with their respective values
+     * @throws GetPropertyException       if the value of a property cannot be obtained
+     * @throws SerializePropertyException if an error occurs during serialization
      */
     public String process(
             String template, Object bean, int serializationType)
-            throws GetPropertyException, SerializePropertyException {
-        Pattern pattern = Pattern.compile("\\$\\{([^}]+)\\}");
+            throws GetPropertyException, SerializePropertyException, FormatterNotFoundException {
+        Pattern pattern = Pattern.compile("\\$\\{([^|{}]+)(?:\\|([^}]+))?\\}");
         Matcher matcher = pattern.matcher(template);
         StringBuffer result = new StringBuffer();
         while (matcher.find()) {
             String property = matcher.group(1);
-            String replacement = serializeProperty(bean, property, serializationType);
+            String formatterName = matcher.group(2);
+            String replacement;
+            if (formatterName != null) {
+                CustomFormatter formatter = formatters.get(formatterName);
+                if (formatter == null) {
+                    throw new FormatterNotFoundException(formatterName);
+                }
+                Object resolvedValue = getPropertyValue(bean, property);
+                replacement = applyFormatter(formatter, property, resolvedValue, bean.getClass());
+            } else {
+                replacement = serializeProperty(bean, property, serializationType);
+            }
             matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
-
         }
         matcher.appendTail(result);
         return result.toString();
+    }
+
+    /**
+     * Applies a registered formatter to a resolved property value.
+     */
+    private String applyFormatter(CustomFormatter formatter, String property,
+            Object resolvedValue, Class<?> beanClass)
+            throws SerializePropertyException {
+        try {
+            String result = formatter.format(property, resolvedValue);
+            return result == null ? "null" : result;
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SerializePropertyException(property, beanClass, e);
+        }
     }
 
     /**
@@ -160,7 +203,13 @@ public class TemplateEngine {
             PropertyDescriptor pd;
             try {
                 String getterName = "get" + Character.toUpperCase(property.charAt(0)) + property.substring(1);
-                pd = new PropertyDescriptor(property, beanClass, getterName, null);
+                try {
+                    pd = new PropertyDescriptor(property, beanClass, getterName, null);
+                } catch (IntrospectionException e) {
+                    // fallback para boolean: isXxx()
+                    String isGetterName = "is" + Character.toUpperCase(property.charAt(0)) + property.substring(1);
+                    pd = new PropertyDescriptor(property, beanClass, isGetterName, null);
+                }
             } catch (IntrospectionException e) {
                 throw new GetPropertyException(property, beanClass, e);
             }

--- a/src/test/java/io/github/moraesdelima/templateengine/Cliente.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/Cliente.java
@@ -6,5 +6,6 @@ import lombok.Data;
 public class Cliente {
     private String nome;
     private int idade;
+    private boolean ativo;
     private Endereco endereco;
 }

--- a/src/test/java/io/github/moraesdelima/templateengine/TemplateEngineTest.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/TemplateEngineTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -328,6 +330,71 @@ public class TemplateEngineTest {
         } catch (Exception e) {
             fail("Unexpected exception: " + e.getMessage());
         }
+    }
+
+    // --- Getter-only virtual property tests ---
+
+    @Test
+    public void test_getter_only_property_with_STRING_SERIALIZATION() {
+        testReplaceProperties(
+                "Registro formatado: ${registroFormatado}",
+                "Registro formatado: REG-123456",
+                TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test
+    public void test_getter_only_property_with_JSON_SERIALIZATION() {
+        testReplaceProperties(
+                "Registro formatado: ${registroFormatado}",
+                "Registro formatado: \"REG-123456\"",
+                TemplateEngine.JSON_SERIALIZATION);
+    }
+
+    @Test
+    public void test_getter_only_property_null_value_with_STRING_SERIALIZATION() {
+        testBean.setRegistro(null);
+        testReplaceProperties(
+                "${registroFormatado}",
+                "null",
+                TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    // --- java.time type tests ---
+
+    @Test
+    public void test_LocalDate_property_with_STRING_SERIALIZATION() {
+        testBean.setDataLocal(LocalDate.of(2024, 3, 27));
+        testReplaceProperties(
+                "Data: ${dataLocal}",
+                "Data: 2024-03-27",
+                TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test
+    public void test_LocalDate_property_with_JSON_SERIALIZATION() {
+        testBean.setDataLocal(LocalDate.of(2024, 3, 27));
+        testReplaceProperties(
+                "Data: ${dataLocal}",
+                "Data: \"2024-03-27\"",
+                TemplateEngine.JSON_SERIALIZATION);
+    }
+
+    @Test
+    public void test_LocalDateTime_property_with_STRING_SERIALIZATION() {
+        testBean.setDataHoraLocal(LocalDateTime.of(2024, 3, 27, 10, 30, 0));
+        testReplaceProperties(
+                "DataHora: ${dataHoraLocal}",
+                "DataHora: 2024-03-27T10:30",
+                TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test
+    public void test_LocalDateTime_property_with_JSON_SERIALIZATION() {
+        testBean.setDataHoraLocal(LocalDateTime.of(2024, 3, 27, 10, 30, 0));
+        testReplaceProperties(
+                "DataHora: ${dataHoraLocal}",
+                "DataHora: \"2024-03-27T10:30\"",
+                TemplateEngine.JSON_SERIALIZATION);
     }
 
 }

--- a/src/test/java/io/github/moraesdelima/templateengine/TemplateEngineTest.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/TemplateEngineTest.java
@@ -587,4 +587,54 @@ public class TemplateEngineTest {
         }
     }
 
+    // --- additional formatter coverage ---
+
+    @Test
+    public void test_formatter_receives_null_resolved_value() throws Exception {
+        engine.registerFormatter("safe", (p, v) -> v == null ? "N/A" : v.toString());
+        testBean.setRegistro(null);
+        String result = engine.process("${registro|safe}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("N/A", result);
+    }
+
+    @Test
+    public void test_formatter_receives_correct_nested_property_name() throws Exception {
+        engine.registerFormatter("upper", (p, v) -> p + "=" + v.toString().toUpperCase());
+        String result = engine.process("${cliente.nome|upper}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("cliente.nome=JOÃO", result);
+    }
+
+    @Test
+    public void test_FormatterNotFoundException_contains_formatter_name() {
+        try {
+            engine.process("${registro|naoExiste}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            fail("Expected FormatterNotFoundException");
+        } catch (FormatterNotFoundException e) {
+            assertEquals("naoExiste", e.getFormatterName());
+        } catch (Exception e) {
+            fail("Expected FormatterNotFoundException, got: " + e.getClass());
+        }
+    }
+
+    @Test
+    public void test_nonexistent_path_with_formatter_throws_GetPropertyException() {
+        engine.registerFormatter("upper", (p, v) -> v.toString().toUpperCase());
+        try {
+            engine.process("${campoInexistente|upper}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            fail("Expected GetPropertyException");
+        } catch (GetPropertyException e) {
+            assertEquals("campoInexistente", e.getProperty());
+        } catch (Exception e) {
+            fail("Expected GetPropertyException, got: " + e.getClass());
+        }
+    }
+
+    @Test
+    public void test_formatter_with_JSON_SERIALIZATION_bypasses_gson() throws Exception {
+        engine.registerFormatter("upper", (p, v) -> v.toString().toUpperCase());
+        String result = engine.process("${cliente.nome|upper}", testBean, TemplateEngine.JSON_SERIALIZATION);
+        // formatter bypasses Gson — no quotes added
+        assertEquals("JOÃO", result);
+    }
+
 }

--- a/src/test/java/io/github/moraesdelima/templateengine/TemplateEngineTest.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/TemplateEngineTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -141,7 +143,7 @@ public class TemplateEngineTest {
     public void test_replacing_an_object_property_with_TemplateEngine_JSON_SERIALIZATION_serialization_Type() {
         testReplaceProperties(
                 "{ \"cliente\": ${cliente} }",
-                "{ \"cliente\": {\"nome\":\"João\",\"idade\":32,\"endereco\":{\"rua\":\"Silveira Martins\",\"numero\":30}} }",
+                "{ \"cliente\": {\"nome\":\"João\",\"idade\":32,\"ativo\":false,\"endereco\":{\"rua\":\"Silveira Martins\",\"numero\":30}} }",
                 TemplateEngine.JSON_SERIALIZATION);
     }
 
@@ -395,6 +397,194 @@ public class TemplateEngineTest {
                 "DataHora: ${dataHoraLocal}",
                 "DataHora: \"2024-03-27T10:30\"",
                 TemplateEngine.JSON_SERIALIZATION);
+    }
+
+    // --- registerFormatter tests ---
+
+    @Test
+    public void test_registerFormatter_simple() {
+        engine.registerFormatter("upper", (p, v) -> v != null ? v.toString().toUpperCase() : "null");
+        testReplaceProperties("${registro|upper}", "123456", TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test
+    public void test_registerFormatter_replaces_existing() {
+        engine.registerFormatter("fmt", (p, v) -> "first");
+        engine.registerFormatter("fmt", (p, v) -> "second");
+        testReplaceProperties("${registro|fmt}", "second", TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_registerFormatter_null_name_throws() {
+        engine.registerFormatter(null, (p, v) -> "x");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_registerFormatter_empty_name_throws() {
+        engine.registerFormatter("", (p, v) -> "x");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_registerFormatter_null_formatter_throws() {
+        engine.registerFormatter("fmt", null);
+    }
+
+    // --- formatter dispatch tests ---
+
+    @Test
+    public void test_formatter_applied_to_placeholder() throws Exception {
+        engine.registerFormatter("upper", (p, v) -> v.toString().toUpperCase());
+        String result = engine.process("Nome: ${cliente.nome|upper}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("Nome: JOÃO", result);
+    }
+
+    @Test
+    public void test_multiple_formatters_in_template() throws Exception {
+        engine.registerFormatter("upper", (p, v) -> v.toString().toUpperCase());
+        engine.registerFormatter("stars", (p, v) -> "***" + v + "***");
+        String result = engine.process("${cliente.nome|upper} ${registro|stars}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("JOÃO ***123456***", result);
+    }
+
+    @Test
+    public void test_mixed_placeholder_with_and_without_formatter() throws Exception {
+        engine.registerFormatter("upper", (p, v) -> v.toString().toUpperCase());
+        String result = engine.process("${registro} ${cliente.nome|upper}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("123456 JOÃO", result);
+    }
+
+    @Test
+    public void test_formatter_returning_null_inserts_null_string() throws Exception {
+        engine.registerFormatter("nullfmt", (p, v) -> null);
+        String result = engine.process("${registro|nullfmt}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("null", result);
+    }
+
+    @Test
+    public void test_formatter_returning_empty_string() throws Exception {
+        engine.registerFormatter("empty", (p, v) -> "");
+        String result = engine.process("${registro|empty}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("", result);
+    }
+
+    @Test(expected = FormatterNotFoundException.class)
+    public void test_unregistered_formatter_throws_FormatterNotFoundException() throws Exception {
+        engine.process("${registro|naoExiste}", testBean, TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test
+    public void test_runtime_exception_propagated_from_formatter() {
+        engine.registerFormatter("boom", (p, v) -> { throw new RuntimeException("boom!"); });
+        try {
+            engine.process("${registro|boom}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            assertEquals("boom!", e.getMessage());
+        } catch (Exception e) {
+            fail("Expected RuntimeException, got: " + e.getClass());
+        }
+    }
+
+    @Test
+    public void test_checked_exception_wrapped_in_SerializePropertyException() {
+        engine.registerFormatter("checked", (p, v) -> { throw new Exception("checked!"); });
+        try {
+            engine.process("${registro|checked}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            fail("Expected SerializePropertyException");
+        } catch (SerializePropertyException e) {
+            assertEquals("checked!", e.getCause().getMessage());
+        } catch (Exception e) {
+            fail("Expected SerializePropertyException, got: " + e.getClass());
+        }
+    }
+
+    // --- date formatting tests ---
+
+    @Test
+    public void test_formatter_LocalDate_to_yyyymmdd() throws Exception {
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMdd");
+        engine.registerFormatter("yyyymmdd", (p, v) -> v != null ? ((LocalDate) v).format(fmt) : "null");
+        testBean.setDataLocal(LocalDate.of(2024, 3, 27));
+        String result = engine.process("${dataLocal|yyyymmdd}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("20240327", result);
+    }
+
+    @Test
+    public void test_formatter_reformat_string_date_ddmmyyyy_to_yyyymmdd() throws Exception {
+        DateTimeFormatter input = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        DateTimeFormatter output = DateTimeFormatter.ofPattern("yyyyMMdd");
+        engine.registerFormatter("reformat", (p, v) -> {
+            if (v == null) return "null";
+            return LocalDate.parse(v.toString(), input).format(output);
+        });
+        testBean.setRegistro("27/03/2024");
+        String result = engine.process("${registro|reformat}", testBean, TemplateEngine.STRING_SERIALIZATION);
+        assertEquals("20240327", result);
+    }
+
+    // --- coverage gap tests ---
+
+    @Test
+    public void test_LocalTime_property_with_STRING_SERIALIZATION() {
+        testBean.setHoraLocal(LocalTime.of(10, 30, 0));
+        testReplaceProperties("Hora: ${horaLocal}", "Hora: 10:30", TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test
+    public void test_LocalTime_property_with_JSON_SERIALIZATION() {
+        testBean.setHoraLocal(LocalTime.of(10, 30, 0));
+        testReplaceProperties("Hora: ${horaLocal}", "Hora: \"10:30\"", TemplateEngine.JSON_SERIALIZATION);
+    }
+
+    @Test
+    public void test_boolean_property_with_STRING_SERIALIZATION() {
+        cliente.setAtivo(true);
+        testReplaceProperties("Ativo: ${cliente.ativo}", "Ativo: true", TemplateEngine.STRING_SERIALIZATION);
+    }
+
+    @Test
+    public void test_boolean_property_with_JSON_SERIALIZATION() {
+        cliente.setAtivo(true);
+        testReplaceProperties("Ativo: ${cliente.ativo}", "Ativo: true", TemplateEngine.JSON_SERIALIZATION);
+    }
+
+    @Test
+    public void test_map_integer_value_with_STRING_SERIALIZATION() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("score", 42));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.score}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            assertEquals("42", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_map_integer_value_with_JSON_SERIALIZATION() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("score", 42));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.score}", testBean, TemplateEngine.JSON_SERIALIZATION);
+            assertEquals("42", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_map_boolean_value_with_STRING_SERIALIZATION() {
+        MapBean mapBean = new MapBean();
+        mapBean.setDados(Map.of("ativo", true));
+        testBean.setMapBean(mapBean);
+        try {
+            String result = engine.process("${mapBean.dados.ativo}", testBean, TemplateEngine.STRING_SERIALIZATION);
+            assertEquals("true", result);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
     }
 
 }

--- a/src/test/java/io/github/moraesdelima/templateengine/TestBean.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/TestBean.java
@@ -1,5 +1,7 @@
 package io.github.moraesdelima.templateengine;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import lombok.Data;
@@ -10,4 +12,11 @@ public class TestBean {
     private Cliente cliente;
     private List<String> lista;
     private MapBean mapBean;
+    private LocalDate dataLocal;
+    private LocalDateTime dataHoraLocal;
+
+    // getter-only virtual property (no backing field, no setter)
+    public String getRegistroFormatado() {
+        return registro != null ? "REG-" + registro : null;
+    }
 }

--- a/src/test/java/io/github/moraesdelima/templateengine/TestBean.java
+++ b/src/test/java/io/github/moraesdelima/templateengine/TestBean.java
@@ -2,6 +2,7 @@ package io.github.moraesdelima.templateengine;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import lombok.Data;
@@ -14,6 +15,7 @@ public class TestBean {
     private MapBean mapBean;
     private LocalDate dataLocal;
     private LocalDateTime dataHoraLocal;
+    private LocalTime horaLocal;
 
     // getter-only virtual property (no backing field, no setter)
     public String getRegistroFormatado() {


### PR DESCRIPTION
## Feature: custom-formatter

Adiciona suporte a formatadores customizados no TemplateEngine via sintaxe `${path|formatterName}`.

### Novidades
- Interface `CustomFormatter` (@FunctionalInterface)
- Exceção `FormatterNotFoundException`
- Método `registerFormatter(String name, CustomFormatter formatter)`
- Regex atualizada para capturar `|formatterName` opcional
- Método privado `applyFormatter` com propagação correta de exceções

### Fixes incluídos
- Suporte a getter boolean via `isXxx()` no PropertyDescriptor

### Cobertura
58 testes cobrindo todos os cenários da spec, incluindo edge cases de formatter com null, path aninhado, exceções e bypass do Gson com JSON_SERIALIZATION.